### PR TITLE
Fix Task Reference handling bug

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,12 +32,18 @@ def group_activities(df_proj):
     """Group & dedupe activities by Task Reference Number in date order."""
     df = df_proj.copy()
     df['Date'] = pd.to_datetime(df['Date'], errors='coerce')
+    # Avoid using Series.replace with an empty string because it treats the
+    # pattern as a regular expression which would replace the empty string in
+    # every position of every value. Instead strip/clean first and then update
+    # only the rows that are actually empty.
     df['Task Reference Number'] = (
         df.get('Task Reference Number', '')
           .fillna('')
           .astype(str)
           .str.strip()
-          .replace('', 'No Reference')
+    )
+    df.loc[df['Task Reference Number'] == '', 'Task Reference Number'] = (
+        'No Reference'
     )
     buckets = {}
     for _, row in df.iterrows():

--- a/tests/test_group_activities.py
+++ b/tests/test_group_activities.py
@@ -1,0 +1,12 @@
+import pandas as pd
+from app import group_activities
+
+def test_group_activities_handles_empty_task_ref():
+    df = pd.DataFrame({
+        'Task Reference Number': ['', None, 'A'],
+        'Date': ['2020-01-01', '2020-01-02', '2020-01-03'],
+        'Modification Details': ['Fix', 'More', 'Other'],
+    })
+    grouped = group_activities(df)
+    assert 'No Reference' in grouped
+    assert 'A' in grouped


### PR DESCRIPTION
## Summary
- avoid pandas Series.replace with an empty string which treated the pattern as a regex and caused corruption
- add regression test for group_activities

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683fdc8647c483238cd07a15ee37e77e