### PR TITLE
Fix placeholder loop

### DIFF
--- a/app.py
+++ b/app.py
@@ -130,9 +130,13 @@ def replace_placeholders_preserve_format(doc, mapping):
         replacements = []
         for key, val in mapping.items():
             placeholder = f"{{{key}}}"
-            idx = full_text.find(placeholder)
-            if idx != -1:
+            start = 0
+            while True:
+                idx = full_text.find(placeholder, start)
+                if idx == -1:
+                    break
                 replacements.append((idx, idx + len(placeholder), str(val)))
+                start = idx + len(placeholder)
 
         if not replacements:
             return  # no "{Key}" in this paragraph

--- a/tests/test_replace_placeholders.py
+++ b/tests/test_replace_placeholders.py
@@ -1,0 +1,10 @@
+import pytest
+from docx import Document
+from app import replace_placeholders_preserve_format
+
+
+def test_replace_multiple_placeholders_in_paragraph():
+    doc = Document()
+    para = doc.add_paragraph("Hello {Name}, again {Name}!")
+    replace_placeholders_preserve_format(doc, {"Name": "World"})
+    assert doc.paragraphs[0].text == "Hello World, again World!"


### PR DESCRIPTION
## Summary
- handle multiple occurrences of a placeholder when replacing text
- test that repeated placeholders are replaced

## Testing
- `pytest -q` *(fails: No module named 'pandas' and 'docx')*

------
https://chatgpt.com/codex/tasks/task_e_683fea59c62c8323985421c28cc4f2da